### PR TITLE
Move model outputs to Hugging Face

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ df_100.csv
 disagreement_scores_per_strata
 default_df_run_experiment.csv
 *.lock
+cache_*
+notebooks/_folder
+output

--- a/README.md
+++ b/README.md
@@ -69,14 +69,13 @@ Note: Currently we do not provide code for computing [Metabench](https://arxiv.o
 ## Download model outputs
 
 To train DISCO you will need model outputs on MMLU, Hellaswag, Winogrande and Arc datasets.
-To download the outputs (~3GB) please run the following command:
+To download the outputs (~3GB), run:
 
 ```
-export DISCO_MODEL_OUTPUTS_HF_BASE=your-org/disco-model-outputs
 python scripts/download_model_outputs.py
 ```
 
-This script will download the file `data/model_outputs.pickle`.
+This fetches the public Hub dataset [`arubique/disco-model-outputs`](https://huggingface.co/datasets/arubique/disco-model-outputs) and writes `data/model_outputs.pickle`.
 
 For more detail see [`docs/datasets.md`](docs/datasets.md).
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,11 @@ Note: All commands are supposed to be run from the root of this repository and a
 - [Notes on `stnd.run_from_csv.py` and `.csv` files](#note-about-stndrun_from_csvpy-and-csv-files)
 - [Citation](#citation)
 
+## Evaluate your model 100x faster
+
+You can use our DISCO-extension to the [MASEval](https://maseval.readthedocs.io/en/stable/) library to evaluate your model on MMLU. Example command can be found [here](https://github.com/parameterlab/MASEval/tree/main/examples/mmlu_benchmark).
+
+Note: This workflow uses the [`arubique/DISCO-MMLU`](https://huggingface.co/arubique/DISCO-MMLU) model and the [`arubique/flattened-MMLU`](https://huggingface.co/datasets/arubique/flattened-MMLU) dataset from the Hugging Face Hub. The dataset is not the MMLU release as originally published: all questions are concatenated in a fixed order in one flat table, without separate splits per subject (subscenario).
 
 ## Evaluate your model 100x faster
 
@@ -69,7 +74,7 @@ Note: Currently we do not provide code for computing [Metabench](https://arxiv.o
 ## Download model outputs
 
 To train DISCO you will need model outputs on MMLU, Hellaswag, Winogrande and Arc datasets.
-To download the outputs (~3GB), run:
+To download the outputs (~300MB), run:
 
 ```
 python scripts/download_model_outputs.py

--- a/README.md
+++ b/README.md
@@ -35,12 +35,7 @@ Note: All commands are supposed to be run from the root of this repository and a
 
 You can use our DISCO-extension to the [MASEval](https://maseval.readthedocs.io/en/stable/) library to evaluate your model on MMLU. Example command can be found [here](https://github.com/parameterlab/MASEval/tree/main/examples/mmlu_benchmark).
 
-Note: This workflow uses the [`arubique/DISCO-MMLU`](https://huggingface.co/arubique/DISCO-MMLU) model and the [`arubique/flattened-MMLU`](https://huggingface.co/datasets/arubique/flattened-MMLU) dataset from the Hugging Face Hub. The dataset is not the MMLU release as originally published: all questions are concatenated in a fixed order in one flat table, without separate splits per subject (subscenario).
-
-## Evaluate your model 100x faster
-
-You can use our DISCO-extension to the [MASEval](https://maseval.readthedocs.io/en/stable/) library to evaluate your model on MMLU. Example command can be found [here](https://github.com/parameterlab/MASEval/tree/main/examples/mmlu_benchmark).
-
+Note: This workflow uses the [`arubique/DISCO-MMLU`](https://huggingface.co/arubique/DISCO-MMLU) model for efficient evaluation of LLMs on the [`arubique/flattened-MMLU`](https://huggingface.co/datasets/arubique/flattened-MMLU) dataset from the Hugging Face Hub. The flattened-MMLU dataset is derived from the original [MMLU](https://huggingface.co/datasets/cais/mmlu) release the following way: all questions are concatenated in a fixed order in one flat table, without separate splits per subject (subscenario).
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -72,10 +72,13 @@ To train DISCO you will need model outputs on MMLU, Hellaswag, Winogrande and Ar
 To download the outputs (~3GB) please run the following command:
 
 ```
+export DISCO_MODEL_OUTPUTS_HF_BASE=your-org/disco-model-outputs
 python scripts/download_model_outputs.py
 ```
 
 This script will download the file `data/model_outputs.pickle`.
+
+For more detail see [`docs/datasets.md`](docs/datasets.md).
 
 ### (Optional) Extract model outputs from open-llm-leaderboard data
 

--- a/docs/datasets.md
+++ b/docs/datasets.md
@@ -1,0 +1,40 @@
+To train DISCO you will need model outputs on MMLU, Hellaswag, Winogrande and Arc datasets.
+The recommended source is the Hugging Face Hub (same content as the former Google Drive archive).
+
+Set the full Hub **dataset repository id** once (`namespace/name`):
+
+```
+export DISCO_MODEL_OUTPUTS_HF_BASE=your-org/disco-model-outputs
+python scripts/download_model_outputs.py
+```
+
+This script writes `data/model_outputs.pickle` by loading that dataset. On the Hub, each block is a **subset / configuration** (`manifest`, `models`, `hellaswag`, `mmlu_*`, …), each with a `train` split, so the viewer can use different columns per subset. Tables are **tabular** (pandas-friendly): the manifest lists `task_split_name` → `original_data_key`; `models` has `model_idx` / `model_name`; each task subset has `sample_idx`, `model_idx`, `correctness`, and `predictions` (list of floats) per row.
+
+To use the legacy Google Drive file instead:
+
+```
+python scripts/download_model_outputs.py --source gdrive
+```
+
+### Upload model outputs to Hugging Face (maintainers)
+
+After you have `data/model_outputs.pickle`, you can publish shards with:
+
+```
+export DISCO_MODEL_OUTPUTS_HF_BASE=your-org/disco-model-outputs
+huggingface-cli login   # or export HF_TOKEN=...
+python scripts/upload_model_outputs_to_hf.py
+```
+
+Use `python scripts/upload_model_outputs_to_hf.py --debug` to push only the `manifest` and `models` splits (two Hub splits, no benchmark data) for a quick connectivity check.
+
+Everything is pushed as **one** dataset repo. The Hub viewer **Subset** menu lists configurations (`manifest`, `models`, `hellaswag`, …); pick a subset then view the `train` split.
+
+To confirm the Hub copy matches a reference `model_outputs.pickle` (for example one downloaded with `--source gdrive`), install test deps and run:
+
+```
+pip install pytest
+export DISCO_MODEL_OUTPUTS_HF_BASE=your-org/disco-model-outputs
+export DISCO_MODEL_OUTPUTS_COMPARE_GDRIVE_PICKLE=/path/to/model_outputs.pickle
+pytest tests/test_model_outputs_hf.py -m integration
+```

--- a/docs/datasets.md
+++ b/docs/datasets.md
@@ -8,7 +8,7 @@ export DISCO_MODEL_OUTPUTS_HF_BASE=your-org/disco-model-outputs
 python scripts/download_model_outputs.py
 ```
 
-This script writes `data/model_outputs.pickle` by loading that dataset. On the Hub, each block is a **subset / configuration** (`manifest`, `models`, `hellaswag`, `mmlu_*`, …), each with a `train` split, so the viewer can use different columns per subset. Tables are **tabular** (pandas-friendly): the manifest lists `task_split_name` → `original_data_key`; `models` has `model_idx` / `model_name`; each task subset has `sample_idx`, `model_idx`, `correctness`, and `predictions` (list of floats) per row.
+This script writes `data/model_outputs.pickle` by loading that dataset. On the Hub, each block is a **subset / configuration** (`manifest`, `models`, `hellaswag`, `mmlu_*`, …), each with a `train` split, so the viewer can use different columns per subset. Tables are **tabular** (pandas-friendly): the manifest lists `task_split_name` → `original_data_key`; `models` has `model_idx` / `model_name`; each task subset has `sample_idx`, `model_idx`, `correctness`, and one column per answer choice (`logit_0`, …) so the Hub table view shows scores without expanding nested lists.
 
 To use the legacy Google Drive file instead:
 
@@ -26,7 +26,7 @@ huggingface-cli login   # or export HF_TOKEN=...
 python scripts/upload_model_outputs_to_hf.py
 ```
 
-Use `python scripts/upload_model_outputs_to_hf.py --debug` to push only the `manifest` and `models` splits (two Hub splits, no benchmark data) for a quick connectivity check.
+Use `python scripts/upload_model_outputs_to_hf.py --debug` to push `manifest`, `models`, and only **Hellaswag** plus **MMLU abstract algebra** (`harness_hellaswag_10`, `harness_hendrycksTest_abstract_algebra_5`) when those keys exist in the pickle—omitting all other tasks.
 
 Everything is pushed as **one** dataset repo. The Hub viewer **Subset** menu lists configurations (`manifest`, `models`, `hellaswag`, …); pick a subset then view the `train` split.
 

--- a/docs/datasets.md
+++ b/docs/datasets.md
@@ -8,7 +8,7 @@ export DISCO_MODEL_OUTPUTS_HF_BASE=your-org/disco-model-outputs
 python scripts/download_model_outputs.py
 ```
 
-This script writes `data/model_outputs.pickle` by loading that dataset. On the Hub, each block is a **subset / configuration** (`manifest`, `models`, `hellaswag`, `mmlu_*`, …), each with a `train` split, so the viewer can use different columns per subset. Tables are **tabular** (pandas-friendly): the manifest lists `task_split_name` → `original_data_key`; `models` has `model_idx` / `model_name`; each task subset has `sample_idx`, `model_idx`, `correctness`, and one column per answer choice (`logit_0`, …) so the Hub table view shows scores without expanding nested lists.
+This script writes `data/model_outputs.pickle` by loading that dataset. On the Hub, each block is a **subset / configuration** (`manifest`, `models`, `hellaswag`, `mmlu_*`, …), each with a `train` split, so the viewer can use different columns per subset. Tables are **tabular** (pandas-friendly): the manifest lists `task_split_name` → `original_data_key`; `models` has `model_idx` / `model_name`; each task subset has `sample_idx`, `model_idx`, `correctness`, and one column per **non-padding** answer choice (`logit_0` … `logit_{k-1}`): trailing columns that are all `-inf`/null in the pickle are omitted on upload. The manifest row for that task includes `prediction_width` (original last-axis length, e.g. 31) so download restores `-inf` padding to match the Google Drive pickle byte-for-byte in array tests.
 
 To use the legacy Google Drive file instead:
 
@@ -29,6 +29,8 @@ python scripts/upload_model_outputs_to_hf.py
 Use `python scripts/upload_model_outputs_to_hf.py --debug` to push `manifest`, `models`, and only **Hellaswag** plus **MMLU abstract algebra** (`harness_hellaswag_10`, `harness_hendrycksTest_abstract_algebra_5`) when those keys exist in the pickle—omitting all other tasks.
 
 Everything is pushed as **one** dataset repo. The Hub viewer **Subset** menu lists configurations (`manifest`, `models`, `hellaswag`, …); pick a subset then view the `train` split.
+
+The dataset repository **`README.md`** on the Hub is uploaded from [`docs/model_outputs_readme.md`](model_outputs_readme.md) on each push (paper link, construction steps, column layout).
 
 To confirm the Hub copy matches a reference `model_outputs.pickle` (for example one downloaded with `--source gdrive`), install test deps and run:
 

--- a/docs/datasets.md
+++ b/docs/datasets.md
@@ -36,7 +36,9 @@ To confirm the Hub copy matches a reference `model_outputs.pickle` (for example 
 
 ```
 pip install pytest
-export DISCO_MODEL_OUTPUTS_HF_BASE=your-org/disco-model-outputs
-export DISCO_MODEL_OUTPUTS_COMPARE_GDRIVE_PICKLE=/path/to/model_outputs.pickle
+export DISCO_MODEL_OUTPUTS_HF_BASE=arubique/disco-model-outputs
+export DISCO_MODEL_OUTPUTS_COMPARE_GDRIVE_PICKLE=data/model_outputs.pickle
 pytest tests/test_model_outputs_hf.py -m integration
 ```
+
+Paths in `DISCO_MODEL_OUTPUTS_COMPARE_GDRIVE_PICKLE` may be relative to the **repository root** (not only the shell cwd). If the basename is `model-outputs.pickle` but the file on disk is `model_outputs.pickle`, the test tries both. If pytest reports `s` (skipped), run `pytest … -rs` to print the skip reason. If the Hub was uploaded with `--debug`, set `DEBUG=1` so the test slices the reference pickle to the same tasks before comparing.

--- a/docs/model_outputs_readme.md
+++ b/docs/model_outputs_readme.md
@@ -1,0 +1,66 @@
+---
+license: other
+language:
+  - en
+task_categories:
+  - other
+tags:
+  - disco
+  - leaderboard
+  - mmlu
+  - hellaswag
+  - winogrande
+  - arc
+  - model-evaluation
+pretty_name: DISCO Model Outputs (Open LLM Leaderboard)
+---
+
+# DISCO model outputs
+
+Tabular release of **per-model, per-item correctness and answer scores** used to train and evaluate [DISCO: Diversifying Sample Condensation for Efficient Model Evaluation](https://huggingface.co/papers/2510.07959). The paper studies cheap benchmark performance prediction from a small subset of evaluation items; this dataset supplies the raw harness-style outputs for MMLU (57 subjects), HellaSwag, Winogrande, ARC, and related tasks from the Open LLM Leaderboard ecosystem.
+
+## Paper
+
+- **Hugging Face Papers:** [2510.07959](https://huggingface.co/papers/2510.07959)  
+- **arXiv:** [2510.07959](https://arxiv.org/abs/2510.07959)
+
+## How this dataset is built (source pipeline)
+
+The on-disk artifact in the [DISCO codebase](https://github.com/arubique/disco-public) is `data/model_outputs.pickle`. It can be **downloaded** from the Hub (see `scripts/download_model_outputs.py`) or **rebuilt from Open LLM Leaderboard snapshots** using the same steps as in the project README:
+
+1. **Extended leaderboard snapshot** (tinyBenchmarks-style Open LLM Leaderboard data), on the order of many hours to fetch:  
+   `python ./scripts/download_leaderboard.py --lb_type openllm_leaderboard --lb_savepath ./data/lb_raw_extended.pickle`
+
+2. **MMLU-fields snapshot** (additional models / fields), on the order of ~1 hour:  
+   `python ./scripts/download_leaderboard.py --lb_type mmlu_fields --lb_savepath ./data/lb_raw.pickle`
+
+3. **Merge and extract** into the ordered pickle consumed by DISCO (~20 minutes):  
+   `python scripts/extract_model_outputs_from_raw_data.py`
+
+That pipeline produces `model_outputs.pickle` with a list of model identifiers and, for each harness task, dense arrays of **correctness** and **per-choice scores** (logits / likelihood-style values as stored by the harness). The Hub upload script flattens those arrays into viewer-friendly tables.
+
+## Hub layout (configs and columns)
+
+This repository is a **multi-config** dataset. Each config corresponds to one logical table; within each config the split is named **`train`**.
+
+| Config | Role |
+|--------|------|
+| `manifest` | Maps Hub config names to original harness keys (`task_split_name` → `original_data_key`). |
+| `models` | `model_idx`, `model_name` — one row per model. |
+| *task configs* | e.g. `hellaswag`, `mmlu_abstract_algebra`, … — long format: `sample_idx`, `model_idx`, `correctness`, and `logit_0` … `logit_{K-1}` for each answer choice. |
+
+Pick a **subset** in the dataset viewer, then open the **`train`** split to inspect rows.
+
+## Code and documentation
+
+- Repository: [github.com/arubique/disco-public](https://github.com/arubique/disco-public)  
+- Hub upload / download helpers: `scripts/model_outputs_hf.py`, `scripts/upload_model_outputs_to_hf.py`, `scripts/download_model_outputs.py`  
+- Extra notes: [`docs/datasets.md`](https://github.com/arubique/disco-public/blob/main/docs/datasets.md) (paths relative to the GitHub repo)
+
+## License
+
+This card uses `license: other` because the release aggregates **derived statistics** from public Open LLM Leaderboard–style evaluations; confirm any reuse constraints with the original benchmark and leaderboard terms.
+
+## Citation
+
+If you use this dataset, please cite the DISCO paper (see the Hugging Face Papers page above for bibliographic metadata).

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,5 +12,7 @@ typer==0.9.4 # needed for operationable py-irt
 click==8.1.8 # needed for operationable py-irt
 py-irt==0.6.5
 datasets==4.0.0
+pandas>=2.0.0
+pytest>=8.0.0
 gdown==4.6.0 # for newer versions of gdown get "too many requests" error
 h5py==3.14.0

--- a/scripts/download_model_outputs.py
+++ b/scripts/download_model_outputs.py
@@ -45,13 +45,23 @@ def download_from_gdrive(output_path: str) -> None:
 
 
 def download_from_hf(
-    output_path: str, hub_base: str, token: Optional[str]
+    output_path: str,
+    hub_base: str,
+    token: Optional[str],
+    *,
+    show_progress: bool = True,
 ) -> None:
     print(
         f"Downloading model outputs from Hugging Face Hub (base={hub_base!r})..."
     )
-    data = download_model_outputs_from_hub(hub_base, token=token)
+    data = download_model_outputs_from_hub(
+        hub_base, token=token, show_progress=show_progress
+    )
     os.makedirs(os.path.dirname(output_path) or ".", exist_ok=True)
+    if show_progress:
+        from tqdm import tqdm
+
+        tqdm.write(f"Writing pickle to {output_path!r}…")
     with open(output_path, "wb") as handle:
         pickle.dump(data, handle, protocol=pickle.HIGHEST_PROTOCOL)
     print(f"Wrote {output_path}")
@@ -86,6 +96,11 @@ def main() -> None:
         default=None,
         help="Hugging Face token (default: HF_TOKEN env or cached login)",
     )
+    parser.add_argument(
+        "--no-progress",
+        action="store_true",
+        help="Disable tqdm progress for Hub download and parquet reassembly",
+    )
     args = parser.parse_args()
 
     if args.source == "gdrive":
@@ -94,7 +109,12 @@ def main() -> None:
 
     hub_base = get_hub_base(args.hub_base)
     token = args.token or os.environ.get("HF_TOKEN")
-    download_from_hf(args.output_path, hub_base, token)
+    download_from_hf(
+        args.output_path,
+        hub_base,
+        token,
+        show_progress=not args.no_progress,
+    )
 
 
 if __name__ == "__main__":

--- a/scripts/download_model_outputs.py
+++ b/scripts/download_model_outputs.py
@@ -1,17 +1,102 @@
-import gdown
+#!/usr/bin/env python3
+"""
+Download `data/model_outputs.pickle` from the Hugging Face Hub (default) or Google Drive.
+
+Hub layout is defined in `scripts/model_outputs_hf.py` (one dataset repo; splits per task).
+
+Examples:
+  export DISCO_MODEL_OUTPUTS_HF_BASE=my-org/disco-public-model-outputs
+  python scripts/download_model_outputs.py
+
+  python scripts/download_model_outputs.py --source gdrive
+"""
+
+import argparse
 import os
+import pickle
+import sys
+from typing import Optional
+
+import gdown
 
 ROOT_PATH = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+SCRIPTS_PATH = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, SCRIPTS_PATH)
 
-# Google Drive file ID and output path
-file_id = "1OFvbunu0MK3kZiM1U6NGi46O5iWE-Fm1"  # Replace with actual Google Drive file ID
-output_path = os.path.join(ROOT_PATH, "data", "model_outputs.pickle")
+from model_outputs_hf import (
+    download_model_outputs_from_hub,
+    get_hub_base,
+)  # noqa: E402
 
-print(f"Downloading pickled model outputs to {output_path}...")
+GDRIVE_FILE_ID = "1OFvbunu0MK3kZiM1U6NGi46O5iWE-Fm1"
+DEFAULT_OUTPUT_PATH = os.path.join(ROOT_PATH, "data", "model_outputs.pickle")
 
-# Download file from Google Drive
-gdown.download(
-    f"https://drive.google.com/uc?id={file_id}", output_path, quiet=False
-)
 
-print("Download complete!")
+def download_from_gdrive(output_path: str) -> None:
+    print(
+        f"Downloading pickled model outputs from Google Drive to {output_path}..."
+    )
+    gdown.download(
+        f"https://drive.google.com/uc?id={GDRIVE_FILE_ID}",
+        output_path,
+        quiet=False,
+    )
+    print("Download complete!")
+
+
+def download_from_hf(
+    output_path: str, hub_base: str, token: Optional[str]
+) -> None:
+    print(
+        f"Downloading model outputs from Hugging Face Hub (base={hub_base!r})..."
+    )
+    data = download_model_outputs_from_hub(hub_base, token=token)
+    os.makedirs(os.path.dirname(output_path) or ".", exist_ok=True)
+    with open(output_path, "wb") as handle:
+        pickle.dump(data, handle, protocol=pickle.HIGHEST_PROTOCOL)
+    print(f"Wrote {output_path}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--source",
+        choices=("hf", "gdrive"),
+        default="hf",
+        help="Where to download from (default: hf)",
+    )
+    parser.add_argument(
+        "--output-path",
+        type=str,
+        default=DEFAULT_OUTPUT_PATH,
+        help=f"Output pickle path (default: {DEFAULT_OUTPUT_PATH})",
+    )
+    parser.add_argument(
+        "--hub-base",
+        type=str,
+        default=None,
+        help="Full Hub dataset repo id org/name. Overrides DISCO_MODEL_OUTPUTS_HF_BASE.",
+    )
+    parser.add_argument(
+        "--token",
+        type=str,
+        default=None,
+        help="Hugging Face token (default: HF_TOKEN env or cached login)",
+    )
+    args = parser.parse_args()
+
+    if args.source == "gdrive":
+        download_from_gdrive(args.output_path)
+        return
+
+    try:
+        hub_base = get_hub_base(args.hub_base)
+    except ValueError as e:
+        raise SystemExit(str(e)) from e
+
+    token = args.token or os.environ.get("HF_TOKEN")
+    download_from_hf(args.output_path, hub_base, token)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/download_model_outputs.py
+++ b/scripts/download_model_outputs.py
@@ -5,9 +5,9 @@ Download `data/model_outputs.pickle` from the Hugging Face Hub (default) or Goog
 Hub layout is defined in `scripts/model_outputs_hf.py` (one dataset repo; splits per task).
 
 Examples:
-  export DISCO_MODEL_OUTPUTS_HF_BASE=my-org/disco-public-model-outputs
   python scripts/download_model_outputs.py
 
+  python scripts/download_model_outputs.py --hub-base my-org/disco-model-outputs
   python scripts/download_model_outputs.py --source gdrive
 """
 
@@ -75,7 +75,10 @@ def main() -> None:
         "--hub-base",
         type=str,
         default=None,
-        help="Full Hub dataset repo id org/name. Overrides DISCO_MODEL_OUTPUTS_HF_BASE.",
+        help=(
+            "Full Hub dataset repo id org/name (default: arubique/disco-model-outputs). "
+            "Overrides DISCO_MODEL_OUTPUTS_HF_BASE if set."
+        ),
     )
     parser.add_argument(
         "--token",
@@ -89,11 +92,7 @@ def main() -> None:
         download_from_gdrive(args.output_path)
         return
 
-    try:
-        hub_base = get_hub_base(args.hub_base)
-    except ValueError as e:
-        raise SystemExit(str(e)) from e
-
+    hub_base = get_hub_base(args.hub_base)
     token = args.token or os.environ.get("HF_TOKEN")
     download_from_hf(args.output_path, hub_base, token)
 

--- a/scripts/model_outputs_hf.py
+++ b/scripts/model_outputs_hf.py
@@ -587,7 +587,9 @@ def _is_tabular_manifest_dataset(manifest_ds: Any) -> bool:
 
 
 def reassemble_model_outputs_from_tabular_splits(
-    splits: Dict[str, Any]
+    splits: Dict[str, Any],
+    *,
+    show_progress: bool = False,
 ) -> Dict[str, Any]:
     """Rebuild from split name -> Dataset (in-memory or loaded one split at a time)."""
     pd = _require_pandas()
@@ -604,12 +606,29 @@ def reassemble_model_outputs_from_tabular_splits(
     mdf = models_ds.to_pandas().sort_values("model_idx", kind="mergesort")
     models = mdf["model_name"].tolist()
 
-    inner: Dict[str, Any] = {}
+    task_rows: List[Any] = []
     for _, row in mf.iterrows():
         sn = str(row["task_split_name"])
         dk = str(row["original_data_key"])
         if not sn or not dk:
             continue
+        task_rows.append(row)
+
+    inner: Dict[str, Any] = {}
+    if show_progress:
+        from tqdm import tqdm
+
+        row_iter = tqdm(
+            task_rows,
+            desc="Parquet → arrays (tasks)",
+            unit="task",
+        )
+    else:
+        row_iter = task_rows
+
+    for row in row_iter:
+        sn = str(row["task_split_name"])
+        dk = str(row["original_data_key"])
         full_dim: Optional[int] = None
         if "prediction_width" in row.index:
             pw = row["prediction_width"]
@@ -655,29 +674,62 @@ def _download_tabular_from_hub(
     manifest_ds: Any,
     *,
     token: Optional[str] = None,
+    show_progress: bool = False,
 ) -> Dict[str, Any]:
     mf = manifest_ds.to_pandas()
     splits_map: Dict[str, Any] = {MANIFEST_SPLIT: manifest_ds}
     model_split_name = str(mf["model_split_name"].iloc[0])
-    splits_map[model_split_name] = _load_hub_config_train(
-        repo_id, model_split_name, token=token
-    )
+
+    to_load: List[Tuple[str, str]] = []
+    seen = {MANIFEST_SPLIT}
+    if model_split_name not in seen:
+        to_load.append((model_split_name, model_split_name))
+        seen.add(model_split_name)
     for _, row in mf.iterrows():
         sn = str(row["task_split_name"])
         dk = str(row["original_data_key"])
         if not sn or not dk:
             continue
-        if sn not in splits_map:
-            splits_map[sn] = _load_hub_config_train(repo_id, sn, token=token)
-    return reassemble_model_outputs_from_tabular_splits(splits_map)
+        if sn not in seen:
+            to_load.append((sn, dk))
+            seen.add(sn)
+
+    pbar = None
+    if show_progress:
+        from tqdm import tqdm
+
+        pbar = tqdm(to_load, desc="Downloading Hub configs", unit="config")
+    iterator = pbar if pbar is not None else to_load
+
+    for config_name, data_key in iterator:
+        if pbar is not None:
+            pbar.set_postfix(
+                config=config_name, ref=data_key[:48], refresh=True
+            )
+        splits_map[config_name] = _load_hub_config_train(
+            repo_id, config_name, token=token
+        )
+
+    return reassemble_model_outputs_from_tabular_splits(
+        splits_map, show_progress=show_progress
+    )
 
 
 def download_model_outputs_from_hub(
     repo_id: str,
     *,
     token: Optional[str] = None,
+    show_progress: bool = False,
 ) -> Dict[str, Any]:
     from datasets import load_dataset
+
+    if show_progress:
+        from tqdm import tqdm
+
+        tqdm.write(f"Loading Hub config {MANIFEST_SPLIT!r}…")
+        _tqdm_write = tqdm.write
+    else:
+        _tqdm_write = None
 
     manifest_ds = None
     try:
@@ -688,7 +740,18 @@ def download_model_outputs_from_hub(
         pass
 
     if manifest_ds is not None and _is_tabular_manifest_dataset(manifest_ds):
-        return _download_tabular_from_hub(repo_id, manifest_ds, token=token)
+        return _download_tabular_from_hub(
+            repo_id,
+            manifest_ds,
+            token=token,
+            show_progress=show_progress,
+        )
 
+    if _tqdm_write:
+        _tqdm_write(
+            "Loading full dataset from Hub (legacy layout; can take several minutes)…"
+        )
     dsd = load_dataset(repo_id, token=token)
+    if _tqdm_write:
+        _tqdm_write("Reassembling legacy pickle layout…")
     return reassemble_model_outputs_from_dataset_dict(dsd)

--- a/scripts/model_outputs_hf.py
+++ b/scripts/model_outputs_hf.py
@@ -57,6 +57,17 @@ DEBUG_UPLOAD_DATA_KEYS: Tuple[str, ...] = (
 )
 
 
+def slice_model_outputs_to_debug_keys(data: Dict[str, Any]) -> Dict[str, Any]:
+    """
+    Keep full ``models`` and only task blocks listed in `DEBUG_UPLOAD_DATA_KEYS` that exist.
+    Use when comparing a full reference pickle to a Hub dataset uploaded with ``--debug``.
+    """
+    inner = {
+        k: data["data"][k] for k in DEBUG_UPLOAD_DATA_KEYS if k in data["data"]
+    }
+    return {"models": data["models"], "data": inner}
+
+
 def _require_pandas() -> Any:
     if pd is None:
         raise ImportError(
@@ -65,16 +76,17 @@ def _require_pandas() -> Any:
     return pd
 
 
+DEFAULT_MODEL_OUTPUTS_HF_REPO = "arubique/disco-model-outputs"
+
+
 def get_hub_base(cli_value: Optional[str]) -> str:
+    """Resolve Hub dataset repo id: CLI ``--hub-base``, then ``DISCO_MODEL_OUTPUTS_HF_BASE``, then default."""
     if cli_value:
         return cli_value
     v = os.environ.get("DISCO_MODEL_OUTPUTS_HF_BASE")
-    if not v:
-        raise ValueError(
-            "Set environment variable DISCO_MODEL_OUTPUTS_HF_BASE or pass --hub-base "
-            "to the full dataset repo id (e.g. my-org/disco-model-outputs)."
-        )
-    return v
+    if v:
+        return v
+    return DEFAULT_MODEL_OUTPUTS_HF_REPO
 
 
 def data_key_to_shard_name(data_key: str) -> str:

--- a/scripts/model_outputs_hf.py
+++ b/scripts/model_outputs_hf.py
@@ -1,0 +1,517 @@
+"""
+Hugging Face Hub layout for `model_outputs.pickle` as a *single* dataset repository.
+
+Splits (manifest, models, hellaswag, mmlu_*, …) are stored as **pandas-friendly tables**
+so the Hub dataset viewer shows real columns. Task splits use long format:
+`sample_idx`, `model_idx`, `correctness`, `predictions` (list of floats).
+
+Each block is pushed as its own Hub **configuration** (`push_to_hub(repo_id, config_name, split="train")`)
+so schemas may differ; the viewer subset dropdown lists config names (`manifest`, `models`, `hellaswag`, …).
+
+Download supports:
+  - **v3 (tabular)**: manifest rows with `original_data_key` column
+  - **v2 (legacy)**: manifest row with `pickle` column containing a pickled dict
+"""
+
+import json
+import os
+import pickle
+import re
+from typing import Any, Dict, List, Optional, Set, Union
+
+import numpy as np
+
+try:
+    import pandas as pd
+except ImportError as e:
+    pd = None  # type: ignore
+    _PANDAS_IMPORT_ERROR = e
+else:
+    _PANDAS_IMPORT_ERROR = None
+
+PICKLE_COLUMN = "pickle"
+SUMMARY_COLUMN = "summary"
+MODELS_SHARD = "models"
+MANIFEST_SPLIT = "manifest"
+MODELS_SPLIT = "models"
+DATA_SHARD_PREFIX = "data__"
+# Hub: v2 = pickle blobs per split; v3 = tabular (pandas) splits
+MANIFEST_FORMAT_VERSION_HUB_PICKLE = 2
+MANIFEST_FORMAT_VERSION_HUB_TABULAR = 3
+MANIFEST_FORMAT_VERSION_LOCAL = 1
+
+RESERVED_SPLIT_NAMES: Set[str] = {MANIFEST_SPLIT, MODELS_SPLIT}
+
+
+def _require_pandas() -> Any:
+    if pd is None:
+        raise ImportError(
+            "pandas is required for tabular Hub upload/download. Install with: pip install pandas"
+        ) from _PANDAS_IMPORT_ERROR
+    return pd
+
+
+def get_hub_base(cli_value: Optional[str]) -> str:
+    if cli_value:
+        return cli_value
+    v = os.environ.get("DISCO_MODEL_OUTPUTS_HF_BASE")
+    if not v:
+        raise ValueError(
+            "Set environment variable DISCO_MODEL_OUTPUTS_HF_BASE or pass --hub-base "
+            "to the full dataset repo id (e.g. my-org/disco-model-outputs)."
+        )
+    return v
+
+
+def data_key_to_shard_name(data_key: str) -> str:
+    return f"{DATA_SHARD_PREFIX}{data_key}"
+
+
+def shard_name_to_data_key(shard_name: str) -> Optional[str]:
+    if shard_name == MODELS_SHARD:
+        return None
+    if not shard_name.startswith(DATA_SHARD_PREFIX):
+        return None
+    return shard_name[len(DATA_SHARD_PREFIX) :]
+
+
+def iter_shard_names(data: Dict[str, Any]) -> List[str]:
+    if "models" not in data or "data" not in data:
+        raise ValueError(
+            "Expected pickle dict with top-level keys 'models' and 'data'."
+        )
+    names = [MODELS_SHARD]
+    names.extend(data_key_to_shard_name(k) for k in sorted(data["data"].keys()))
+    return names
+
+
+def build_manifest(data: Dict[str, Any]) -> Dict[str, Any]:
+    """Local / test manifest listing internal shard names (v1)."""
+    return {
+        "format_version": MANIFEST_FORMAT_VERSION_LOCAL,
+        "shards": iter_shard_names(data),
+    }
+
+
+def split_model_outputs_to_shards(data: Dict[str, Any]) -> Dict[str, Any]:
+    """Map shard_name -> object (for local tests)."""
+    shards: Dict[str, Any] = {MODELS_SHARD: data["models"]}
+    for key in sorted(data["data"].keys()):
+        shards[data_key_to_shard_name(key)] = data["data"][key]
+    return shards
+
+
+def merge_shards_to_model_outputs(
+    shard_objects: Dict[str, Any]
+) -> Dict[str, Any]:
+    if MODELS_SHARD not in shard_objects:
+        raise ValueError(f"Missing shard {MODELS_SHARD!r}")
+    models = shard_objects[MODELS_SHARD]
+    inner: Dict[str, Any] = {}
+    for name, obj in shard_objects.items():
+        if name == MODELS_SHARD:
+            continue
+        key = shard_name_to_data_key(name)
+        if key is None:
+            raise ValueError(f"Unexpected shard name: {name!r}")
+        inner[key] = obj
+    return {"models": models, "data": inner}
+
+
+def model_outputs_equal(a: Dict[str, Any], b: Dict[str, Any]) -> bool:
+    try:
+        assert_model_outputs_equal(a, b)
+        return True
+    except AssertionError:
+        return False
+
+
+def assert_model_outputs_equal(a: Dict[str, Any], b: Dict[str, Any]) -> None:
+    assert set(a.keys()) == {"models", "data"}
+    assert set(b.keys()) == {"models", "data"}
+    assert a["models"] == b["models"]
+    assert set(a["data"].keys()) == set(b["data"].keys())
+    for k in a["data"]:
+        da, db = a["data"][k], b["data"][k]
+        assert set(da.keys()) == set(db.keys())
+        for kk in da:
+            va, vb = da[kk], db[kk]
+            if isinstance(va, np.ndarray) and isinstance(vb, np.ndarray):
+                np.testing.assert_array_equal(va, vb)
+            else:
+                assert va == vb
+
+
+def _sanitize_split_name(name: str) -> str:
+    s = re.sub(r"[^a-zA-Z0-9_]+", "_", name)
+    s = re.sub(r"_+", "_", s).strip("_")
+    if not s:
+        s = "split"
+    if s[0].isdigit():
+        s = "s_" + s
+    return s[:200]
+
+
+def default_split_name_for_data_key(data_key: str) -> str:
+    if data_key == "harness_arc_challenge_25":
+        base = "arc_challenge"
+    elif data_key == "harness_hellaswag_10":
+        base = "hellaswag"
+    elif data_key == "harness_winogrande_5":
+        base = "winogrande"
+    elif data_key.startswith("harness_truthfulqa"):
+        base = "truthfulqa_" + data_key[len("harness_truthfulqa_") :]
+    elif data_key.startswith("harness_hendrycksTest_"):
+        rest = data_key[len("harness_hendrycksTest_") :]
+        if rest.endswith("_5"):
+            rest = rest[:-2]
+        base = "mmlu_" + rest
+    elif data_key.startswith("harness_"):
+        base = data_key[len("harness_") :]
+    else:
+        base = data_key
+    return _sanitize_split_name(base)
+
+
+def build_hub_split_layout(
+    data: Dict[str, Any], *, debug: bool = False
+) -> Dict[str, Any]:
+    used: Set[str] = set(RESERVED_SPLIT_NAMES)
+    data_splits: Dict[str, str] = {}
+    if debug:
+        return {
+            "format_version": MANIFEST_FORMAT_VERSION_HUB_TABULAR,
+            "model_split": MODELS_SPLIT,
+            "data_splits": data_splits,
+        }
+    for dk in sorted(data["data"].keys()):
+        base = default_split_name_for_data_key(dk)
+        sn = base
+        n = 2
+        while sn in used:
+            sn = _sanitize_split_name(f"{base}__{n}")
+            n += 1
+        used.add(sn)
+        data_splits[sn] = dk
+    return {
+        "format_version": MANIFEST_FORMAT_VERSION_HUB_TABULAR,
+        "model_split": MODELS_SPLIT,
+        "data_splits": data_splits,
+    }
+
+
+def _blob_to_bytes(blob: Any) -> bytes:
+    if isinstance(blob, bytes):
+        return blob
+    if isinstance(blob, (memoryview, bytearray)):
+        return bytes(blob)
+    return bytes(blob)
+
+
+def _task_block_to_dataframe(block: Dict[str, Any]) -> Any:
+    pd = _require_pandas()
+    c = np.asarray(block["correctness"], dtype=np.float64)
+    p = np.asarray(block["predictions"], dtype=np.float64)
+    if c.ndim != 2 or p.ndim != 3:
+        raise ValueError(
+            f"Expected correctness (S,M) and predictions (S,M,A); got {c.shape}, {p.shape}"
+        )
+    S, M = c.shape
+    A = p.shape[2]
+    sample_idx = np.repeat(np.arange(S, dtype=np.int64), M)
+    model_idx = np.tile(np.arange(M, dtype=np.int64), S)
+    correctness = c.reshape(-1, order="C")
+    pred_flat = p.reshape(S * M, A)
+    predictions = [pred_flat[i].tolist() for i in range(S * M)]
+    return pd.DataFrame(
+        {
+            "sample_idx": sample_idx,
+            "model_idx": model_idx,
+            "correctness": correctness,
+            "predictions": predictions,
+        }
+    )
+
+
+def _dataframe_to_task_block(df: Any) -> Dict[str, np.ndarray]:
+    _require_pandas()
+    df = df.sort_values(
+        ["sample_idx", "model_idx"], kind="mergesort"
+    ).reset_index(drop=True)
+    S = int(df["sample_idx"].max()) + 1
+    M = int(df["model_idx"].max()) + 1
+    first = df["predictions"].iloc[0]
+    if isinstance(first, np.ndarray):
+        A = int(first.shape[0])
+    else:
+        A = len(first)
+    pred_stack = np.stack(
+        [np.asarray(x, dtype=np.float64) for x in df["predictions"].values]
+    )
+    predictions = pred_stack.reshape(S, M, A)
+    correctness = df["correctness"].values.reshape(S, M, order="C")
+    return {"correctness": correctness, "predictions": predictions}
+
+
+def _build_manifest_dataframe(layout: Dict[str, Any]) -> Any:
+    pd = _require_pandas()
+    rows = []
+    for sn, dk in sorted(layout["data_splits"].items()):
+        rows.append(
+            {
+                "format_version": MANIFEST_FORMAT_VERSION_HUB_TABULAR,
+                "model_split_name": layout["model_split"],
+                "task_split_name": sn,
+                "original_data_key": dk,
+            }
+        )
+    if not rows:
+        rows.append(
+            {
+                "format_version": MANIFEST_FORMAT_VERSION_HUB_TABULAR,
+                "model_split_name": layout["model_split"],
+                "task_split_name": "",
+                "original_data_key": "",
+            }
+        )
+    return pd.DataFrame(rows)
+
+
+def _tabular_dataset_features():
+    from datasets import Features, Sequence, Value
+
+    manifest_features = Features(
+        {
+            "format_version": Value("int64"),
+            "model_split_name": Value("string"),
+            "task_split_name": Value("string"),
+            "original_data_key": Value("string"),
+        }
+    )
+    models_features = Features(
+        {
+            "model_idx": Value("int64"),
+            "model_name": Value("string"),
+        }
+    )
+    task_features = Features(
+        {
+            "sample_idx": Value("int64"),
+            "model_idx": Value("int64"),
+            "correctness": Value("float64"),
+            "predictions": Sequence(Value("float64")),
+        }
+    )
+    return manifest_features, models_features, task_features
+
+
+def build_tabular_hub_splits(
+    data: Dict[str, Any], *, debug: bool = False
+) -> Dict[str, Any]:
+    """
+    Map split_name -> Dataset built from pandas tables (Hub viewer friendly).
+    """
+    from datasets import Dataset
+
+    layout = build_hub_split_layout(data, debug=debug)
+    mf, mof, tf = _tabular_dataset_features()
+    pd = _require_pandas()
+
+    out: Dict[str, Any] = {}
+
+    manifest_df = _build_manifest_dataframe(layout)
+    out[MANIFEST_SPLIT] = Dataset.from_pandas(
+        manifest_df, preserve_index=False, features=mf
+    )
+
+    models_df = pd.DataFrame(
+        {
+            "model_idx": np.arange(len(data["models"]), dtype=np.int64),
+            "model_name": [str(x) for x in data["models"]],
+        }
+    )
+    out[MODELS_SPLIT] = Dataset.from_pandas(
+        models_df, preserve_index=False, features=mof
+    )
+
+    for sn, dk in sorted(layout["data_splits"].items()):
+        tdf = _task_block_to_dataframe(data["data"][dk])
+        out[sn] = Dataset.from_pandas(tdf, preserve_index=False, features=tf)
+
+    return out
+
+
+def build_model_outputs_dataset_dict(
+    data: Dict[str, Any], *, debug: bool = False
+) -> Any:
+    """In-memory DatasetDict of tabular splits (for local tests; schemas differ per split)."""
+    from datasets import DatasetDict
+
+    parts = build_tabular_hub_splits(data, debug=debug)
+    return DatasetDict(parts)
+
+
+def push_model_outputs_to_hub(
+    repo_id: str,
+    data: Dict[str, Any],
+    *,
+    token: Optional[str] = None,
+    private: bool = False,
+    debug: bool = False,
+) -> None:
+    if "/" not in repo_id:
+        raise ValueError(
+            f"repo_id must be a full Hub dataset id 'org/name', got: {repo_id!r}"
+        )
+
+    from huggingface_hub import HfApi
+
+    api = HfApi(token=token)
+    api.create_repo(
+        repo_id,
+        repo_type="dataset",
+        private=private,
+        exist_ok=True,
+        token=token,
+    )
+
+    splits = build_tabular_hub_splits(data, debug=debug)
+    huge: Union[int, str] = 1 << 40
+    order = [MANIFEST_SPLIT, MODELS_SPLIT] + sorted(
+        k for k in splits if k not in (MANIFEST_SPLIT, MODELS_SPLIT)
+    )
+    for name in order:
+        # One Hub *config* per block; a single split "train" inside each config. Using only
+        # Hub splits would force identical features across the whole repo (HF error).
+        splits[name].push_to_hub(
+            repo_id,
+            name,
+            split="train",
+            private=private,
+            token=token,
+            max_shard_size=huge,
+        )
+
+
+def _manifest_dict_from_row(mrow: Any) -> Dict[str, Any]:
+    """Legacy pickle manifest (v2) or old int64/string/json columns."""
+    blob_raw = mrow.get(PICKLE_COLUMN)
+    if blob_raw is not None:
+        blob = _blob_to_bytes(blob_raw)
+        if len(blob) > 0:
+            obj = pickle.loads(blob)
+            if isinstance(obj, dict) and "data_splits" in obj:
+                return obj
+    if "data_splits_json" in mrow and mrow["data_splits_json"] is not None:
+        return {
+            "format_version": int(mrow["format_version"]),
+            "model_split": str(mrow["model_split"]),
+            "data_splits": json.loads(mrow["data_splits_json"]),
+        }
+    raise ValueError(
+        f"Unrecognized manifest split row: keys={list(mrow.keys())}"
+    )
+
+
+def _is_tabular_manifest_dataset(manifest_ds: Any) -> bool:
+    return "original_data_key" in manifest_ds.column_names
+
+
+def reassemble_model_outputs_from_tabular_splits(
+    splits: Dict[str, Any]
+) -> Dict[str, Any]:
+    """Rebuild from split name -> Dataset (in-memory or loaded one split at a time)."""
+    manifest_ds = splits[MANIFEST_SPLIT]
+    mf = manifest_ds.to_pandas()
+    version = int(mf["format_version"].iloc[0])
+    if version != MANIFEST_FORMAT_VERSION_HUB_TABULAR:
+        raise ValueError(
+            f"Expected tabular hub format_version {MANIFEST_FORMAT_VERSION_HUB_TABULAR}, got {version!r}"
+        )
+    model_split_name = str(mf["model_split_name"].iloc[0])
+
+    models_ds = splits[model_split_name]
+    mdf = models_ds.to_pandas().sort_values("model_idx", kind="mergesort")
+    models = mdf["model_name"].tolist()
+
+    inner: Dict[str, Any] = {}
+    for _, row in mf.iterrows():
+        sn = str(row["task_split_name"])
+        dk = str(row["original_data_key"])
+        if not sn or not dk:
+            continue
+        inner[dk] = _dataframe_to_task_block(splits[sn].to_pandas())
+    return {"models": models, "data": inner}
+
+
+def reassemble_model_outputs_from_dataset_dict(dsd: Any) -> Dict[str, Any]:
+    """Rebuild pickle dict from a loaded DatasetDict (legacy v2 pickle splits on Hub)."""
+    mrow = dsd[MANIFEST_SPLIT][0]
+    manifest_obj = _manifest_dict_from_row(mrow)
+    version = int(manifest_obj["format_version"])
+    if version != MANIFEST_FORMAT_VERSION_HUB_PICKLE:
+        raise ValueError(
+            f"Unsupported legacy pickle manifest format_version: {version!r} "
+            f"(expected {MANIFEST_FORMAT_VERSION_HUB_PICKLE})"
+        )
+    data_splits: Dict[str, str] = dict(manifest_obj["data_splits"])
+    model_split = str(manifest_obj["model_split"])
+
+    models = pickle.loads(_blob_to_bytes(dsd[model_split][0][PICKLE_COLUMN]))
+    inner: Dict[str, Any] = {}
+    for sn, dk in data_splits.items():
+        inner[dk] = pickle.loads(_blob_to_bytes(dsd[sn][0][PICKLE_COLUMN]))
+    return {"models": models, "data": inner}
+
+
+def _load_hub_config_train(
+    repo_id: str, config_name: str, *, token: Optional[str] = None
+) -> Any:
+    from datasets import load_dataset
+
+    ds = load_dataset(repo_id, config_name, split="train", token=token)
+    return ds
+
+
+def _download_tabular_from_hub(
+    repo_id: str,
+    manifest_ds: Any,
+    *,
+    token: Optional[str] = None,
+) -> Dict[str, Any]:
+    mf = manifest_ds.to_pandas()
+    splits_map: Dict[str, Any] = {MANIFEST_SPLIT: manifest_ds}
+    model_split_name = str(mf["model_split_name"].iloc[0])
+    splits_map[model_split_name] = _load_hub_config_train(
+        repo_id, model_split_name, token=token
+    )
+    for _, row in mf.iterrows():
+        sn = str(row["task_split_name"])
+        dk = str(row["original_data_key"])
+        if not sn or not dk:
+            continue
+        if sn not in splits_map:
+            splits_map[sn] = _load_hub_config_train(repo_id, sn, token=token)
+    return reassemble_model_outputs_from_tabular_splits(splits_map)
+
+
+def download_model_outputs_from_hub(
+    repo_id: str,
+    *,
+    token: Optional[str] = None,
+) -> Dict[str, Any]:
+    from datasets import load_dataset
+
+    manifest_ds = None
+    try:
+        manifest_ds = _load_hub_config_train(
+            repo_id, MANIFEST_SPLIT, token=token
+        )
+    except Exception:
+        pass
+
+    if manifest_ds is not None and _is_tabular_manifest_dataset(manifest_ds):
+        return _download_tabular_from_hub(repo_id, manifest_ds, token=token)
+
+    dsd = load_dataset(repo_id, token=token)
+    return reassemble_model_outputs_from_dataset_dict(dsd)

--- a/scripts/model_outputs_hf.py
+++ b/scripts/model_outputs_hf.py
@@ -3,10 +3,12 @@ Hugging Face Hub layout for `model_outputs.pickle` as a *single* dataset reposit
 
 Splits (manifest, models, hellaswag, mmlu_*, …) are stored as **pandas-friendly tables**
 so the Hub dataset viewer shows real columns. Task subsets use long format: one row per
-(sample, model) with `sample_idx`, `model_idx`, `correctness`, and one float column per
-answer choice (`logit_0` … `logit_{K-1}`) so scores appear as normal table columns (the
-viewer does not list nested sequences well). Legacy Hub files may still use a `predictions`
-list column; download supports both.
+(sample, model) with `sample_idx`, `model_idx`, `correctness`, and `logit_0` … `logit_{k-1}`
+for leading scores only. Trailing choice columns that are entirely non-finite padding (`-inf`
+/ NaN in the pickle) are **dropped** on upload. The manifest stores `prediction_width`
+(original `predictions.shape[2]`) per task; download **pads** with `-inf` to restore the
+same arrays as the source pickle. Legacy Hub tables may lack `prediction_width` or use a
+`predictions` list column; download supports both.
 
 Each block is pushed as its own Hub **configuration** (`push_to_hub(repo_id, config_name, split="train")`)
 so schemas may differ; the viewer subset dropdown lists config names (`manifest`, `models`, `hellaswag`, …).
@@ -44,6 +46,9 @@ MANIFEST_FORMAT_VERSION_HUB_TABULAR = 3
 MANIFEST_FORMAT_VERSION_LOCAL = 1
 
 RESERVED_SPLIT_NAMES: Set[str] = {MANIFEST_SPLIT, MODELS_SPLIT}
+
+# Matches `pad_predictions` in utils_for_notebooks: unused answer slots in the pickle.
+PREDICTION_PADDING_VALUE = float("-inf")
 
 # With --debug upload: only these harness keys (if present in the pickle) plus manifest/models.
 DEBUG_UPLOAD_DATA_KEYS: Tuple[str, ...] = (
@@ -182,29 +187,30 @@ def default_split_name_for_data_key(data_key: str) -> str:
     return _sanitize_split_name(base)
 
 
+def _prediction_full_width(block: Dict[str, Any]) -> int:
+    return int(np.asarray(block["predictions"], dtype=np.float64).shape[2])
+
+
+def _trimmed_logit_column_count(p: np.ndarray) -> int:
+    """Drop trailing columns that are entirely non-finite (Hub shows them as nulls)."""
+    p = np.asarray(p, dtype=np.float64)
+    if p.ndim != 3:
+        raise ValueError(f"predictions must be (S,M,A); got {p.shape}")
+    _, _, a = p.shape
+    k = a
+    while k > 0 and np.all(~np.isfinite(p[:, :, k - 1])):
+        k -= 1
+    return max(k, 1)
+
+
 def build_hub_split_layout(
     data: Dict[str, Any], *, debug: bool = False
 ) -> Dict[str, Any]:
     used: Set[str] = set(RESERVED_SPLIT_NAMES)
     data_splits: Dict[str, str] = {}
-    if debug:
-        for dk in DEBUG_UPLOAD_DATA_KEYS:
-            if dk not in data["data"]:
-                continue
-            base = default_split_name_for_data_key(dk)
-            sn = base
-            n = 2
-            while sn in used:
-                sn = _sanitize_split_name(f"{base}__{n}")
-                n += 1
-            used.add(sn)
-            data_splits[sn] = dk
-        return {
-            "format_version": MANIFEST_FORMAT_VERSION_HUB_TABULAR,
-            "model_split": MODELS_SPLIT,
-            "data_splits": data_splits,
-        }
-    for dk in sorted(data["data"].keys()):
+    prediction_widths: Dict[str, int] = {}
+
+    def _add_task(dk: str) -> None:
         base = default_split_name_for_data_key(dk)
         sn = base
         n = 2
@@ -213,10 +219,21 @@ def build_hub_split_layout(
             n += 1
         used.add(sn)
         data_splits[sn] = dk
+        prediction_widths[sn] = _prediction_full_width(data["data"][dk])
+
+    if debug:
+        for dk in DEBUG_UPLOAD_DATA_KEYS:
+            if dk in data["data"]:
+                _add_task(dk)
+    else:
+        for dk in sorted(data["data"].keys()):
+            _add_task(dk)
+
     return {
         "format_version": MANIFEST_FORMAT_VERSION_HUB_TABULAR,
         "model_split": MODELS_SPLIT,
         "data_splits": data_splits,
+        "prediction_widths": prediction_widths,
     }
 
 
@@ -229,6 +246,7 @@ def _blob_to_bytes(blob: Any) -> bytes:
 
 
 def _task_block_to_dataframe(block: Dict[str, Any]) -> Any:
+    """Long-format rows; only leading logit_* columns (trailing all-padding columns omitted)."""
     pd = _require_pandas()
     c = np.asarray(block["correctness"], dtype=np.float64)
     p = np.asarray(block["predictions"], dtype=np.float64)
@@ -237,17 +255,20 @@ def _task_block_to_dataframe(block: Dict[str, Any]) -> Any:
             f"Expected correctness (S,M) and predictions (S,M,A); got {c.shape}, {p.shape}"
         )
     S, M = c.shape
-    A = p.shape[2]
+    a_full = p.shape[2]
+    k = _trimmed_logit_column_count(p)
+    if k > a_full:
+        k = a_full
     sample_idx = np.repeat(np.arange(S, dtype=np.int64), M)
     model_idx = np.tile(np.arange(M, dtype=np.int64), S)
     correctness = c.reshape(-1, order="C")
-    pred_flat = p.reshape(S * M, A)
+    pred_flat = p.reshape(S * M, a_full)
     col_data: Dict[str, Any] = {
         "sample_idx": sample_idx,
         "model_idx": model_idx,
         "correctness": correctness.astype(np.float64),
     }
-    for j in range(A):
+    for j in range(k):
         col_data[f"logit_{j}"] = pred_flat[:, j].astype(np.float64)
     return pd.DataFrame(col_data)
 
@@ -271,7 +292,15 @@ def _task_features_for_num_choices(num_choices: int) -> Any:
     return Features(fields)
 
 
-def _dataframe_to_task_block(df: Any) -> Dict[str, np.ndarray]:
+def _dataframe_to_task_block(
+    df: Any, *, full_answer_dim: Optional[int] = None
+) -> Dict[str, np.ndarray]:
+    """
+    Rebuild correctness (S,M) and predictions (S,M,A).
+
+    If full_answer_dim is set (from manifest `prediction_width`), pad trailing choice
+    dimensions with PREDICTION_PADDING_VALUE so the array matches the original pickle.
+    """
     _require_pandas()
     df = df.sort_values(
         ["sample_idx", "model_idx"], kind="mergesort"
@@ -283,13 +312,13 @@ def _dataframe_to_task_block(df: Any) -> Dict[str, np.ndarray]:
     if "predictions" in df.columns:
         first = df["predictions"].iloc[0]
         if isinstance(first, np.ndarray):
-            A = int(first.shape[0])
+            a = int(first.shape[0])
         else:
-            A = len(first)
+            a = len(first)
         pred_stack = np.stack(
             [np.asarray(x, dtype=np.float64) for x in df["predictions"].values]
         )
-        predictions = pred_stack.reshape(S, M, A)
+        predictions = pred_stack.reshape(S, M, a)
         return {"correctness": correctness, "predictions": predictions}
 
     logit_cols = _logit_column_names(df)
@@ -297,16 +326,28 @@ def _dataframe_to_task_block(df: Any) -> Dict[str, np.ndarray]:
         raise ValueError(
             "Task table has no logit_* columns and no predictions column; cannot rebuild arrays."
         )
-    A = len(logit_cols)
+    k = len(logit_cols)
     pred_stack = np.column_stack(
         [df[c].astype(np.float64).values for c in logit_cols]
     )
-    predictions = pred_stack.reshape(S, M, A)
+    a_target = full_answer_dim if full_answer_dim is not None else k
+    if a_target < k:
+        raise ValueError(
+            f"prediction_width {a_target} < number of logit columns {k}"
+        )
+    if a_target == k:
+        predictions = pred_stack.reshape(S, M, k)
+    else:
+        predictions = np.full(
+            (S, M, a_target), PREDICTION_PADDING_VALUE, dtype=np.float64
+        )
+        predictions[:, :, :k] = pred_stack.reshape(S, M, k)
     return {"correctness": correctness, "predictions": predictions}
 
 
 def _build_manifest_dataframe(layout: Dict[str, Any]) -> Any:
     pd = _require_pandas()
+    widths: Dict[str, int] = layout.get("prediction_widths") or {}
     rows = []
     for sn, dk in sorted(layout["data_splits"].items()):
         rows.append(
@@ -315,6 +356,7 @@ def _build_manifest_dataframe(layout: Dict[str, Any]) -> Any:
                 "model_split_name": layout["model_split"],
                 "task_split_name": sn,
                 "original_data_key": dk,
+                "prediction_width": int(widths.get(sn, 0)),
             }
         )
     if not rows:
@@ -324,6 +366,7 @@ def _build_manifest_dataframe(layout: Dict[str, Any]) -> Any:
                 "model_split_name": layout["model_split"],
                 "task_split_name": "",
                 "original_data_key": "",
+                "prediction_width": 0,
             }
         )
     return pd.DataFrame(rows)
@@ -338,6 +381,7 @@ def _tabular_manifest_and_models_features():
             "model_split_name": Value("string"),
             "task_split_name": Value("string"),
             "original_data_key": Value("string"),
+            "prediction_width": Value("int64"),
         }
     )
     models_features = Features(
@@ -380,12 +424,8 @@ def build_tabular_hub_splits(
 
     for sn, dk in sorted(layout["data_splits"].items()):
         tdf = _task_block_to_dataframe(data["data"][dk])
-        A = int(
-            np.asarray(data["data"][dk]["predictions"], dtype=np.float64).shape[
-                2
-            ]
-        )
-        tf = _task_features_for_num_choices(A)
+        n_logit_cols = len(_logit_column_names(tdf))
+        tf = _task_features_for_num_choices(n_logit_cols)
         out[sn] = Dataset.from_pandas(tdf, preserve_index=False, features=tf)
 
     return out
@@ -442,6 +482,73 @@ def push_model_outputs_to_hub(
             max_shard_size=huge,
         )
 
+    _upload_model_outputs_dataset_readme(repo_id, token=token)
+
+
+def _merge_model_outputs_readme(
+    static_readme_text: str, hub_readme_text: str
+) -> str:
+    """
+    Combine the curated dataset card (license, tags, markdown body) with YAML metadata
+    produced on the Hub by ``datasets`` (``configs``, ``dataset_info``).
+
+    ``push_to_hub`` writes those keys into README.md; uploading the static card alone
+    would drop them and the Hub viewer would only show a subset of configurations.
+    """
+    from huggingface_hub.repocard import DatasetCard
+    from huggingface_hub.repocard_data import DatasetCardData
+
+    static_card = DatasetCard(static_readme_text)
+    hub_card = DatasetCard(hub_readme_text)
+    merged_dict = {**static_card.data.to_dict(), **hub_card.data.to_dict()}
+    merged_data = DatasetCardData(ignore_metadata_errors=True, **merged_dict)
+    line_break = "\n"
+    raw = (
+        f"---{line_break}{merged_data.to_yaml(line_break=line_break)}"
+        f"{line_break}---{line_break}{static_card.text}"
+    )
+    return DatasetCard(raw).content
+
+
+def _upload_model_outputs_dataset_readme(
+    repo_id: str,
+    *,
+    token: Optional[str] = None,
+) -> None:
+    """Upload the curated card merged with Hub metadata (configs / dataset_info)."""
+    from pathlib import Path
+
+    from huggingface_hub import HfApi, hf_hub_download
+    from huggingface_hub.errors import EntryNotFoundError
+
+    root = Path(__file__).resolve().parent.parent
+    readme_path = root / "docs" / "model_outputs_readme.md"
+    if not readme_path.is_file():
+        raise FileNotFoundError(
+            f"Dataset README missing (expected {readme_path}). "
+            "Add docs/model_outputs_readme.md before pushing."
+        )
+    static_text = readme_path.read_text(encoding="utf-8")
+    try:
+        remote_path = hf_hub_download(
+            repo_id,
+            "README.md",
+            repo_type="dataset",
+            token=token,
+        )
+        hub_text = Path(remote_path).read_text(encoding="utf-8")
+        payload = _merge_model_outputs_readme(static_text, hub_text)
+    except EntryNotFoundError:
+        payload = static_text
+    api = HfApi(token=token)
+    api.upload_file(
+        path_or_fileobj=payload.encode("utf-8"),
+        path_in_repo="README.md",
+        repo_id=repo_id,
+        repo_type="dataset",
+        token=token,
+    )
+
 
 def _manifest_dict_from_row(mrow: Any) -> Dict[str, Any]:
     """Legacy pickle manifest (v2) or old int64/string/json columns."""
@@ -471,6 +578,7 @@ def reassemble_model_outputs_from_tabular_splits(
     splits: Dict[str, Any]
 ) -> Dict[str, Any]:
     """Rebuild from split name -> Dataset (in-memory or loaded one split at a time)."""
+    pd = _require_pandas()
     manifest_ds = splits[MANIFEST_SPLIT]
     mf = manifest_ds.to_pandas()
     version = int(mf["format_version"].iloc[0])
@@ -490,7 +598,14 @@ def reassemble_model_outputs_from_tabular_splits(
         dk = str(row["original_data_key"])
         if not sn or not dk:
             continue
-        inner[dk] = _dataframe_to_task_block(splits[sn].to_pandas())
+        full_dim: Optional[int] = None
+        if "prediction_width" in row.index:
+            pw = row["prediction_width"]
+            if pd.notna(pw) and int(pw) > 0:
+                full_dim = int(pw)
+        inner[dk] = _dataframe_to_task_block(
+            splits[sn].to_pandas(), full_answer_dim=full_dim
+        )
     return {"models": models, "data": inner}
 
 

--- a/scripts/model_outputs_hf.py
+++ b/scripts/model_outputs_hf.py
@@ -2,8 +2,11 @@
 Hugging Face Hub layout for `model_outputs.pickle` as a *single* dataset repository.
 
 Splits (manifest, models, hellaswag, mmlu_*, …) are stored as **pandas-friendly tables**
-so the Hub dataset viewer shows real columns. Task splits use long format:
-`sample_idx`, `model_idx`, `correctness`, `predictions` (list of floats).
+so the Hub dataset viewer shows real columns. Task subsets use long format: one row per
+(sample, model) with `sample_idx`, `model_idx`, `correctness`, and one float column per
+answer choice (`logit_0` … `logit_{K-1}`) so scores appear as normal table columns (the
+viewer does not list nested sequences well). Legacy Hub files may still use a `predictions`
+list column; download supports both.
 
 Each block is pushed as its own Hub **configuration** (`push_to_hub(repo_id, config_name, split="train")`)
 so schemas may differ; the viewer subset dropdown lists config names (`manifest`, `models`, `hellaswag`, …).
@@ -17,7 +20,7 @@ import json
 import os
 import pickle
 import re
-from typing import Any, Dict, List, Optional, Set, Union
+from typing import Any, Dict, List, Optional, Set, Tuple, Union
 
 import numpy as np
 
@@ -41,6 +44,12 @@ MANIFEST_FORMAT_VERSION_HUB_TABULAR = 3
 MANIFEST_FORMAT_VERSION_LOCAL = 1
 
 RESERVED_SPLIT_NAMES: Set[str] = {MANIFEST_SPLIT, MODELS_SPLIT}
+
+# With --debug upload: only these harness keys (if present in the pickle) plus manifest/models.
+DEBUG_UPLOAD_DATA_KEYS: Tuple[str, ...] = (
+    "harness_hellaswag_10",
+    "harness_hendrycksTest_abstract_algebra_5",
+)
 
 
 def _require_pandas() -> Any:
@@ -179,6 +188,17 @@ def build_hub_split_layout(
     used: Set[str] = set(RESERVED_SPLIT_NAMES)
     data_splits: Dict[str, str] = {}
     if debug:
+        for dk in DEBUG_UPLOAD_DATA_KEYS:
+            if dk not in data["data"]:
+                continue
+            base = default_split_name_for_data_key(dk)
+            sn = base
+            n = 2
+            while sn in used:
+                sn = _sanitize_split_name(f"{base}__{n}")
+                n += 1
+            used.add(sn)
+            data_splits[sn] = dk
         return {
             "format_version": MANIFEST_FORMAT_VERSION_HUB_TABULAR,
             "model_split": MODELS_SPLIT,
@@ -222,15 +242,33 @@ def _task_block_to_dataframe(block: Dict[str, Any]) -> Any:
     model_idx = np.tile(np.arange(M, dtype=np.int64), S)
     correctness = c.reshape(-1, order="C")
     pred_flat = p.reshape(S * M, A)
-    predictions = [pred_flat[i].tolist() for i in range(S * M)]
-    return pd.DataFrame(
-        {
-            "sample_idx": sample_idx,
-            "model_idx": model_idx,
-            "correctness": correctness,
-            "predictions": predictions,
-        }
-    )
+    col_data: Dict[str, Any] = {
+        "sample_idx": sample_idx,
+        "model_idx": model_idx,
+        "correctness": correctness.astype(np.float64),
+    }
+    for j in range(A):
+        col_data[f"logit_{j}"] = pred_flat[:, j].astype(np.float64)
+    return pd.DataFrame(col_data)
+
+
+def _logit_column_names(df: Any) -> List[str]:
+    names = [c for c in df.columns if c.startswith("logit_")]
+    names.sort(key=lambda x: int(x.split("_", 1)[1]))
+    return names
+
+
+def _task_features_for_num_choices(num_choices: int) -> Any:
+    from datasets import Features, Value
+
+    fields: Dict[str, Any] = {
+        "sample_idx": Value("int64"),
+        "model_idx": Value("int64"),
+        "correctness": Value("float64"),
+    }
+    for j in range(num_choices):
+        fields[f"logit_{j}"] = Value("float64")
+    return Features(fields)
 
 
 def _dataframe_to_task_block(df: Any) -> Dict[str, np.ndarray]:
@@ -240,16 +278,30 @@ def _dataframe_to_task_block(df: Any) -> Dict[str, np.ndarray]:
     ).reset_index(drop=True)
     S = int(df["sample_idx"].max()) + 1
     M = int(df["model_idx"].max()) + 1
-    first = df["predictions"].iloc[0]
-    if isinstance(first, np.ndarray):
-        A = int(first.shape[0])
-    else:
-        A = len(first)
-    pred_stack = np.stack(
-        [np.asarray(x, dtype=np.float64) for x in df["predictions"].values]
+    correctness = df["correctness"].values.reshape(S, M, order="C")
+
+    if "predictions" in df.columns:
+        first = df["predictions"].iloc[0]
+        if isinstance(first, np.ndarray):
+            A = int(first.shape[0])
+        else:
+            A = len(first)
+        pred_stack = np.stack(
+            [np.asarray(x, dtype=np.float64) for x in df["predictions"].values]
+        )
+        predictions = pred_stack.reshape(S, M, A)
+        return {"correctness": correctness, "predictions": predictions}
+
+    logit_cols = _logit_column_names(df)
+    if not logit_cols:
+        raise ValueError(
+            "Task table has no logit_* columns and no predictions column; cannot rebuild arrays."
+        )
+    A = len(logit_cols)
+    pred_stack = np.column_stack(
+        [df[c].astype(np.float64).values for c in logit_cols]
     )
     predictions = pred_stack.reshape(S, M, A)
-    correctness = df["correctness"].values.reshape(S, M, order="C")
     return {"correctness": correctness, "predictions": predictions}
 
 
@@ -277,8 +329,8 @@ def _build_manifest_dataframe(layout: Dict[str, Any]) -> Any:
     return pd.DataFrame(rows)
 
 
-def _tabular_dataset_features():
-    from datasets import Features, Sequence, Value
+def _tabular_manifest_and_models_features():
+    from datasets import Features, Value
 
     manifest_features = Features(
         {
@@ -294,15 +346,7 @@ def _tabular_dataset_features():
             "model_name": Value("string"),
         }
     )
-    task_features = Features(
-        {
-            "sample_idx": Value("int64"),
-            "model_idx": Value("int64"),
-            "correctness": Value("float64"),
-            "predictions": Sequence(Value("float64")),
-        }
-    )
-    return manifest_features, models_features, task_features
+    return manifest_features, models_features
 
 
 def build_tabular_hub_splits(
@@ -314,7 +358,7 @@ def build_tabular_hub_splits(
     from datasets import Dataset
 
     layout = build_hub_split_layout(data, debug=debug)
-    mf, mof, tf = _tabular_dataset_features()
+    mf, mof = _tabular_manifest_and_models_features()
     pd = _require_pandas()
 
     out: Dict[str, Any] = {}
@@ -336,6 +380,12 @@ def build_tabular_hub_splits(
 
     for sn, dk in sorted(layout["data_splits"].items()):
         tdf = _task_block_to_dataframe(data["data"][dk])
+        A = int(
+            np.asarray(data["data"][dk]["predictions"], dtype=np.float64).shape[
+                2
+            ]
+        )
+        tf = _task_features_for_num_choices(A)
         out[sn] = Dataset.from_pandas(tdf, preserve_index=False, features=tf)
 
     return out

--- a/scripts/upload_model_outputs_to_hf.py
+++ b/scripts/upload_model_outputs_to_hf.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""
+Upload `data/model_outputs.pickle` to the Hugging Face Hub as a *single* dataset repo.
+
+The Hub dataset uses one configuration (subset) per logical block (manifest, models,
+hellaswag, mmlu_*, …), each with a `train` split, so the viewer can show different columns
+per subset. If an earlier upload mixed layouts on the same repo, delete the repo (or use a
+new name) before pushing again.
+
+Requires: `huggingface-cli login` or HF_TOKEN in the environment.
+
+Example:
+  export DISCO_MODEL_OUTPUTS_HF_BASE=my-org/disco-model-outputs
+  huggingface-cli login
+  python scripts/upload_model_outputs_to_hf.py
+
+  # Quick test: only manifest + models splits (no benchmark data on the Hub)
+  python scripts/upload_model_outputs_to_hf.py --debug
+"""
+
+import argparse
+import os
+import pickle
+import sys
+
+ROOT_PATH = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+SCRIPTS_PATH = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, SCRIPTS_PATH)
+
+from model_outputs_hf import (
+    get_hub_base,
+    push_model_outputs_to_hub,
+)  # noqa: E402
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--pickle-path",
+        type=str,
+        default=os.path.join(ROOT_PATH, "data", "model_outputs.pickle"),
+        help="Path to model_outputs.pickle",
+    )
+    parser.add_argument(
+        "--hub-base",
+        type=str,
+        default=None,
+        help="Full Hub dataset repo id org/name (e.g. org/disco-model-outputs). "
+        "Overrides DISCO_MODEL_OUTPUTS_HF_BASE.",
+    )
+    parser.add_argument(
+        "--private",
+        action="store_true",
+        help="Create a private dataset repo",
+    )
+    parser.add_argument(
+        "--token",
+        type=str,
+        default=None,
+        help="Hugging Face token (default: HF_TOKEN env or cached login)",
+    )
+    parser.add_argument(
+        "--debug",
+        action="store_true",
+        help="Upload only two splits (manifest + models); omit all benchmark splits",
+    )
+    args = parser.parse_args()
+
+    try:
+        repo_id = get_hub_base(args.hub_base)
+    except ValueError as e:
+        raise SystemExit(str(e)) from e
+
+    with open(args.pickle_path, "rb") as f:
+        data = pickle.load(f)
+
+    token = args.token or os.environ.get("HF_TOKEN")
+    if args.debug:
+        print(
+            f"Pushing debug dataset (manifest + models only) to {repo_id} ..."
+        )
+    else:
+        print(f"Pushing single dataset to {repo_id} ...")
+    push_model_outputs_to_hub(
+        repo_id, data, token=token, private=args.private, debug=args.debug
+    )
+    print("Upload complete.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/upload_model_outputs_to_hf.py
+++ b/scripts/upload_model_outputs_to_hf.py
@@ -10,9 +10,11 @@ new name) before pushing again.
 Requires: `huggingface-cli login` or HF_TOKEN in the environment.
 
 Example:
-  export DISCO_MODEL_OUTPUTS_HF_BASE=my-org/disco-model-outputs
   huggingface-cli login
   python scripts/upload_model_outputs_to_hf.py
+
+  # Fork or custom repo:
+  python scripts/upload_model_outputs_to_hf.py --hub-base my-org/disco-model-outputs
 
   # Quick test: manifest + models + hellaswag + MMLU abstract algebra (if present in pickle)
   python scripts/upload_model_outputs_to_hf.py --debug
@@ -45,8 +47,10 @@ def main() -> None:
         "--hub-base",
         type=str,
         default=None,
-        help="Full Hub dataset repo id org/name (e.g. org/disco-model-outputs). "
-        "Overrides DISCO_MODEL_OUTPUTS_HF_BASE.",
+        help=(
+            "Full Hub dataset repo id org/name (default: arubique/disco-model-outputs). "
+            "Overrides DISCO_MODEL_OUTPUTS_HF_BASE if set."
+        ),
     )
     parser.add_argument(
         "--private",
@@ -69,10 +73,7 @@ def main() -> None:
     )
     args = parser.parse_args()
 
-    try:
-        repo_id = get_hub_base(args.hub_base)
-    except ValueError as e:
-        raise SystemExit(str(e)) from e
+    repo_id = get_hub_base(args.hub_base)
 
     with open(args.pickle_path, "rb") as f:
         data = pickle.load(f)

--- a/scripts/upload_model_outputs_to_hf.py
+++ b/scripts/upload_model_outputs_to_hf.py
@@ -14,7 +14,7 @@ Example:
   huggingface-cli login
   python scripts/upload_model_outputs_to_hf.py
 
-  # Quick test: only manifest + models splits (no benchmark data on the Hub)
+  # Quick test: manifest + models + hellaswag + MMLU abstract algebra (if present in pickle)
   python scripts/upload_model_outputs_to_hf.py --debug
 """
 
@@ -62,7 +62,10 @@ def main() -> None:
     parser.add_argument(
         "--debug",
         action="store_true",
-        help="Upload only two splits (manifest + models); omit all benchmark splits",
+        help=(
+            "Upload manifest + models + only harness_hellaswag_10 and "
+            "harness_hendrycksTest_abstract_algebra_5 (if present); omit other tasks"
+        ),
     )
     args = parser.parse_args()
 
@@ -77,7 +80,8 @@ def main() -> None:
     token = args.token or os.environ.get("HF_TOKEN")
     if args.debug:
         print(
-            f"Pushing debug dataset (manifest + models only) to {repo_id} ..."
+            f"Pushing debug dataset (manifest + models + hellaswag + mmlu abstract algebra "
+            f"if present) to {repo_id} ..."
         )
     else:
         print(f"Pushing single dataset to {repo_id} ...")

--- a/tests/test_model_outputs_hf.py
+++ b/tests/test_model_outputs_hf.py
@@ -18,6 +18,7 @@ sys.path.insert(0, str(SCRIPTS))
 
 from model_outputs_hf import (  # noqa: E402
     MANIFEST_FORMAT_VERSION_HUB_TABULAR,
+    _merge_model_outputs_readme,
     assert_model_outputs_equal,
     build_manifest,
     build_hub_split_layout,
@@ -88,6 +89,29 @@ def test_hub_split_layout_unique_and_reserved():
     assert "manifest" not in names
     assert "models" not in names
     assert len(names) == len(layout["data_splits"])
+    assert layout["prediction_widths"]["arc_challenge"] == 5
+    assert layout["prediction_widths"]["hellaswag"] == 10
+
+
+def test_trailing_padding_logits_omitted_on_hub_and_restored_on_download():
+    p = np.ones((1, 2, 10), dtype=np.float64)
+    p[:, :, 5:] = float("-inf")
+    data = {
+        "models": ["m1", "m2"],
+        "data": {
+            "harness_hellaswag_10": {
+                "correctness": np.array([[0.5, 1.0]], dtype=np.float64),
+                "predictions": p,
+            }
+        },
+    }
+    dd = build_model_outputs_dataset_dict(data)
+    logit_cols = [
+        c for c in dd["hellaswag"].to_pandas().columns if c.startswith("logit_")
+    ]
+    assert len(logit_cols) == 5
+    out = reassemble_model_outputs_from_tabular_splits(dict(dd))
+    assert_model_outputs_equal(data, out)
 
 
 def test_datasetdict_reassemble_roundtrip_local():
@@ -110,6 +134,42 @@ def test_debug_datasetdict_only_hellaswag_when_mmlu_absent():
         "data": {"harness_hellaswag_10": data["data"]["harness_hellaswag_10"]},
     }
     assert_model_outputs_equal(partial, out)
+
+
+def test_merge_readme_keeps_hub_configs_and_static_body():
+    """Curated README must not replace datasets-generated ``configs`` (Hub viewer)."""
+    static = """---
+license: other
+tags:
+  - disco
+pretty_name: DISCO Model Outputs
+---
+
+# Curated title
+
+Curated body.
+"""
+    hub = """---
+configs:
+  - config_name: manifest
+    data_files:
+      - split: train
+        path: manifest/train-*
+  - config_name: hellaswag
+    data_files:
+      - split: train
+        path: hellaswag/train-*
+---
+
+auto-generated
+"""
+    out = _merge_model_outputs_readme(static, hub)
+    assert "configs:" in out
+    assert "hellaswag" in out
+    assert "manifest/train-*" in out
+    assert "disco" in out
+    assert "# Curated title" in out
+    assert "Curated body." in out
 
 
 def test_debug_datasetdict_includes_mmlu_abstract_algebra_when_present():

--- a/tests/test_model_outputs_hf.py
+++ b/tests/test_model_outputs_hf.py
@@ -17,6 +17,7 @@ SCRIPTS = ROOT / "scripts"
 sys.path.insert(0, str(SCRIPTS))
 
 from model_outputs_hf import (  # noqa: E402
+    DEFAULT_MODEL_OUTPUTS_HF_REPO,
     MANIFEST_FORMAT_VERSION_HUB_TABULAR,
     _merge_model_outputs_readme,
     assert_model_outputs_equal,
@@ -24,9 +25,11 @@ from model_outputs_hf import (  # noqa: E402
     build_hub_split_layout,
     build_model_outputs_dataset_dict,
     download_model_outputs_from_hub,
+    get_hub_base,
     iter_shard_names,
     merge_shards_to_model_outputs,
     reassemble_model_outputs_from_tabular_splits,
+    slice_model_outputs_to_debug_keys,
     split_model_outputs_to_shards,
 )
 
@@ -45,6 +48,12 @@ def _minimal_model_outputs() -> dict:
             },
         },
     }
+
+
+def test_get_hub_base_default_without_env(monkeypatch):
+    monkeypatch.delenv("DISCO_MODEL_OUTPUTS_HF_BASE", raising=False)
+    assert get_hub_base(None) == DEFAULT_MODEL_OUTPUTS_HF_REPO
+    assert get_hub_base("other/repo") == "other/repo"
 
 
 def test_iter_shard_names_order():
@@ -172,6 +181,21 @@ auto-generated
     assert "Curated body." in out
 
 
+def test_slice_model_outputs_to_debug_keys():
+    data = _minimal_model_outputs()
+    data["data"]["harness_hendrycksTest_abstract_algebra_5"] = {
+        "correctness": np.array([[1.0, 0.0]], dtype=np.float64),
+        "predictions": np.zeros((1, 2, 5), dtype=np.float64),
+    }
+    sub = slice_model_outputs_to_debug_keys(data)
+    assert sub["models"] == data["models"]
+    assert set(sub["data"].keys()) == {
+        "harness_hellaswag_10",
+        "harness_hendrycksTest_abstract_algebra_5",
+    }
+    assert "harness_arc_challenge_25" not in sub["data"]
+
+
 def test_debug_datasetdict_includes_mmlu_abstract_algebra_when_present():
     data = _minimal_model_outputs()
     data["data"]["harness_hendrycksTest_abstract_algebra_5"] = {
@@ -189,31 +213,79 @@ def test_debug_datasetdict_includes_mmlu_abstract_algebra_when_present():
     }
 
 
+def _resolve_reference_pickle_path(raw: str) -> Path:
+    p = Path(raw).expanduser()
+    if not p.is_absolute():
+        p = ROOT / p
+    return p.resolve()
+
+
+def _reference_pickle_search_paths(raw: str) -> list[Path]:
+    """
+    Resolve env path from repo root, then common typo: model-outputs vs model_outputs basename.
+    """
+    primary = _resolve_reference_pickle_path(raw)
+    candidates = [primary]
+    stem = primary.stem
+    if stem in ("model-outputs", "model_outputs"):
+        alt_stem = (
+            "model_outputs" if stem == "model-outputs" else "model-outputs"
+        )
+        candidates.append(primary.with_name(alt_stem + primary.suffix))
+    seen: set[Path] = set()
+    ordered: list[Path] = []
+    for p in candidates:
+        rp = p.resolve()
+        if rp not in seen:
+            seen.add(rp)
+            ordered.append(rp)
+    return ordered
+
+
 @pytest.mark.integration
 def test_hf_hub_matches_reference_gdrive_pickle():
     """
-    Compare a reference pickle (obtained from Google Drive via gdown or any mirror)
-    to the object reassembled from the Hugging Face Hub.
+    Compare a reference pickle (e.g. from Google Drive) to data reassembled from the Hub.
 
     Set:
-      DISCO_MODEL_OUTPUTS_HF_BASE=org/disco-model-outputs
-      DISCO_MODEL_OUTPUTS_COMPARE_GDRIVE_PICKLE=/path/to/model_outputs.pickle
+      DISCO_MODEL_OUTPUTS_COMPARE_GDRIVE_PICKLE=path/to/model_outputs.pickle
+        (relative paths are resolved from the repository root, not only cwd)
+      DISCO_MODEL_OUTPUTS_HF_BASE=org/disco-model-outputs  (optional if default in get_hub_base)
+
+    Set DEBUG=1 to compare only tasks uploaded with ``--debug`` (hellaswag + mmlu abstract
+    algebra when present); the Hub dataset must have been pushed with ``--debug``.
 
     Optional: HF_TOKEN if the datasets are private.
     """
-    ref_path = os.environ.get("DISCO_MODEL_OUTPUTS_COMPARE_GDRIVE_PICKLE")
-    hf_repo = os.environ.get("DISCO_MODEL_OUTPUTS_HF_BASE")
-    if not ref_path or not hf_repo:
+    raw_ref = os.environ.get("DISCO_MODEL_OUTPUTS_COMPARE_GDRIVE_PICKLE")
+    if not raw_ref:
         pytest.skip(
-            "Set DISCO_MODEL_OUTPUTS_COMPARE_GDRIVE_PICKLE and DISCO_MODEL_OUTPUTS_HF_BASE "
-            "to run Hub vs Google Drive pickle comparison."
+            "Set DISCO_MODEL_OUTPUTS_COMPARE_GDRIVE_PICKLE to run this integration test."
         )
-    if not os.path.isfile(ref_path):
-        pytest.skip(f"Reference pickle not found: {ref_path}")
 
-    with open(ref_path, "rb") as handle:
+    tried = _reference_pickle_search_paths(raw_ref)
+    ref_path = next((p for p in tried if p.is_file()), None)
+    if ref_path is None:
+        pytest.skip(
+            "Reference pickle not found. Tried:\n  "
+            + "\n  ".join(str(p) for p in tried)
+            + f"\n(DISCO_MODEL_OUTPUTS_COMPARE_GDRIVE_PICKLE={raw_ref!r}, repo root={ROOT}). "
+            "Typo: use model_outputs.pickle (underscore) not model-outputs.pickle. "
+            "Re-run with pytest -rs to show this skip reason."
+        )
+
+    try:
+        hf_repo = get_hub_base(os.environ.get("DISCO_MODEL_OUTPUTS_HF_BASE"))
+    except ValueError as e:
+        pytest.skip(str(e))
+
+    with ref_path.open("rb") as handle:
         reference = pickle.load(handle)
 
     token = os.environ.get("HF_TOKEN")
     from_hub = download_model_outputs_from_hub(hf_repo, token=token)
+
+    if os.environ.get("DEBUG", "").strip() == "1":
+        reference = slice_model_outputs_to_debug_keys(reference)
+
     assert_model_outputs_equal(reference, from_hub)

--- a/tests/test_model_outputs_hf.py
+++ b/tests/test_model_outputs_hf.py
@@ -97,13 +97,36 @@ def test_datasetdict_reassemble_roundtrip_local():
     assert_model_outputs_equal(data, out)
 
 
-def test_debug_datasetdict_has_two_splits_only():
+def test_debug_datasetdict_only_hellaswag_when_mmlu_absent():
     data = _minimal_model_outputs()
     dd = build_model_outputs_dataset_dict(data, debug=True)
-    assert set(dd.keys()) == {"manifest", "models"}
+    assert set(dd.keys()) == {"manifest", "models", "hellaswag"}
+    assert "arc_challenge" not in dd
     out = reassemble_model_outputs_from_tabular_splits(dict(dd))
     assert out["models"] == data["models"]
-    assert out["data"] == {}
+    assert set(out["data"].keys()) == {"harness_hellaswag_10"}
+    partial = {
+        "models": data["models"],
+        "data": {"harness_hellaswag_10": data["data"]["harness_hellaswag_10"]},
+    }
+    assert_model_outputs_equal(partial, out)
+
+
+def test_debug_datasetdict_includes_mmlu_abstract_algebra_when_present():
+    data = _minimal_model_outputs()
+    data["data"]["harness_hendrycksTest_abstract_algebra_5"] = {
+        "correctness": np.array([[1.0, 0.0]], dtype=np.float64),
+        "predictions": np.zeros((1, 2, 5), dtype=np.float64),
+    }
+    dd = build_model_outputs_dataset_dict(data, debug=True)
+    assert "hellaswag" in dd
+    assert "mmlu_abstract_algebra" in dd
+    assert "arc_challenge" not in dd
+    out = reassemble_model_outputs_from_tabular_splits(dict(dd))
+    assert set(out["data"].keys()) == {
+        "harness_hellaswag_10",
+        "harness_hendrycksTest_abstract_algebra_5",
+    }
 
 
 @pytest.mark.integration

--- a/tests/test_model_outputs_hf.py
+++ b/tests/test_model_outputs_hf.py
@@ -1,0 +1,136 @@
+"""
+Tests for Hugging Face layout of model_outputs.pickle.
+
+Integration test (HF vs reference pickle) runs only when env vars are set; see docstring below.
+"""
+
+import os
+import pickle
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS = ROOT / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+from model_outputs_hf import (  # noqa: E402
+    MANIFEST_FORMAT_VERSION_HUB_TABULAR,
+    assert_model_outputs_equal,
+    build_manifest,
+    build_hub_split_layout,
+    build_model_outputs_dataset_dict,
+    download_model_outputs_from_hub,
+    iter_shard_names,
+    merge_shards_to_model_outputs,
+    reassemble_model_outputs_from_tabular_splits,
+    split_model_outputs_to_shards,
+)
+
+
+def _minimal_model_outputs() -> dict:
+    return {
+        "models": ["m1", "m2"],
+        "data": {
+            "harness_arc_challenge_25": {
+                "correctness": np.array([[1.0, 0.0]], dtype=np.float64),
+                "predictions": np.zeros((1, 2, 5), dtype=np.float64),
+            },
+            "harness_hellaswag_10": {
+                "correctness": np.array([[0.5, 1.0]], dtype=np.float64),
+                "predictions": np.ones((1, 2, 10), dtype=np.float64),
+            },
+        },
+    }
+
+
+def test_iter_shard_names_order():
+    data = _minimal_model_outputs()
+    names = iter_shard_names(data)
+    assert names[0] == "models"
+    assert names[1:] == sorted(names[1:])
+
+
+def test_split_merge_roundtrip():
+    data = _minimal_model_outputs()
+    shards = split_model_outputs_to_shards(data)
+    merged = merge_shards_to_model_outputs(shards)
+    assert_model_outputs_equal(data, merged)
+
+
+def test_build_manifest_lists_shards():
+    data = _minimal_model_outputs()
+    m = build_manifest(data)
+    assert m["shards"] == iter_shard_names(data)
+
+
+def test_pickle_bytes_roundtrip_per_shard():
+    """Same bytes workflow as Hub (pickle column would hold these blobs)."""
+    data = _minimal_model_outputs()
+    shards = split_model_outputs_to_shards(data)
+    blobs = {
+        k: pickle.dumps(v, protocol=pickle.HIGHEST_PROTOCOL)
+        for k, v in shards.items()
+    }
+    restored = {k: pickle.loads(b) for k, b in blobs.items()}
+    merged = merge_shards_to_model_outputs(restored)
+    assert_model_outputs_equal(data, merged)
+
+
+def test_hub_split_layout_unique_and_reserved():
+    data = _minimal_model_outputs()
+    layout = build_hub_split_layout(data)
+    assert layout["format_version"] == MANIFEST_FORMAT_VERSION_HUB_TABULAR
+    assert layout["model_split"] == "models"
+    names = set(layout["data_splits"].keys())
+    assert "manifest" not in names
+    assert "models" not in names
+    assert len(names) == len(layout["data_splits"])
+
+
+def test_datasetdict_reassemble_roundtrip_local():
+    data = _minimal_model_outputs()
+    dd = build_model_outputs_dataset_dict(data)
+    out = reassemble_model_outputs_from_tabular_splits(dict(dd))
+    assert_model_outputs_equal(data, out)
+
+
+def test_debug_datasetdict_has_two_splits_only():
+    data = _minimal_model_outputs()
+    dd = build_model_outputs_dataset_dict(data, debug=True)
+    assert set(dd.keys()) == {"manifest", "models"}
+    out = reassemble_model_outputs_from_tabular_splits(dict(dd))
+    assert out["models"] == data["models"]
+    assert out["data"] == {}
+
+
+@pytest.mark.integration
+def test_hf_hub_matches_reference_gdrive_pickle():
+    """
+    Compare a reference pickle (obtained from Google Drive via gdown or any mirror)
+    to the object reassembled from the Hugging Face Hub.
+
+    Set:
+      DISCO_MODEL_OUTPUTS_HF_BASE=org/disco-model-outputs
+      DISCO_MODEL_OUTPUTS_COMPARE_GDRIVE_PICKLE=/path/to/model_outputs.pickle
+
+    Optional: HF_TOKEN if the datasets are private.
+    """
+    ref_path = os.environ.get("DISCO_MODEL_OUTPUTS_COMPARE_GDRIVE_PICKLE")
+    hf_repo = os.environ.get("DISCO_MODEL_OUTPUTS_HF_BASE")
+    if not ref_path or not hf_repo:
+        pytest.skip(
+            "Set DISCO_MODEL_OUTPUTS_COMPARE_GDRIVE_PICKLE and DISCO_MODEL_OUTPUTS_HF_BASE "
+            "to run Hub vs Google Drive pickle comparison."
+        )
+    if not os.path.isfile(ref_path):
+        pytest.skip(f"Reference pickle not found: {ref_path}")
+
+    with open(ref_path, "rb") as handle:
+        reference = pickle.load(handle)
+
+    token = os.environ.get("HF_TOKEN")
+    from_hub = download_model_outputs_from_hub(hf_repo, token=token)
+    assert_model_outputs_equal(reference, from_hub)


### PR DESCRIPTION
## Summary

Adds Hugging Face support for model_outputs.pickle: upload/download scripts, tabular multi-config layout in model_outputs_hf.py, tests (including optional Hub-vs-pickle integration). Google Drive download remains via --source gdrive.

## Related issue
Closes #3 